### PR TITLE
_security object additions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 Sag Changes
 ===========
 
+Version 0.5.0
+-------------
+
+New Features
+
+Fixed Bugs
+
 Version 0.4.0
 -------------
 

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Sag
 ===
 
-Version 0.4.0
+Version 0.5.0-UNRELEASED
 http://www.saggingcouch.com
 
 Sag is a simple PHP library for working with CouchDB. It is designed to not

--- a/src/Sag.php
+++ b/src/Sag.php
@@ -22,7 +22,7 @@ require_once('SagConfigurationCheck.php');
 /**
  * The Sag class provides the core functionality for talking to CouchDB.
  *
- * @version 0.4.0
+ * @version 0.5.0
  * @package Core
  */
 class Sag
@@ -767,7 +767,7 @@ class Sag
 
     // Build the request packet.
     $headers["Host"] = "{$this->host}:{$this->port}";
-    $headers["User-Agent"] = "Sag/0.4";
+    $headers["User-Agent"] = "Sag/0.5";
 
     //usernames and passwords can be blank
     if($this->authType == Sag::$AUTH_BASIC && (isset($this->user) || isset($this->pass)))

--- a/src/SagCache.php
+++ b/src/SagCache.php
@@ -27,7 +27,7 @@ require_once("SagException.php");
  * storage).
  *
  * @package Cache 
- * @version 0.4.0
+ * @version 0.5.0
  */
 abstract class SagCache 
 {

--- a/src/SagConfigurationCheck.php
+++ b/src/SagConfigurationCheck.php
@@ -21,7 +21,7 @@
  * a user-level notice message to inform the client of Sag's preferred
  * configuration.
  *
- * @version 0.4.0
+ * @version 0.5.0
  * @package Core
  */
 class SagConfigurationCheck

--- a/src/SagCouchException.php
+++ b/src/SagCouchException.php
@@ -23,7 +23,7 @@
  * if the requested document isn't found, then the code would be set to "404"
  * (string).
  *
- * @version 0.4.0
+ * @version 0.5.0
  * @package Core
  */
 class SagCouchException extends Exception

--- a/src/SagException.php
+++ b/src/SagException.php
@@ -19,7 +19,7 @@
  * This exception is thrown when Sag has an internal error, such as an invalid
  * type being passed to a function.
  *
- * @version 0.4.0
+ * @version 0.5.0
  * @package Core
  */
 class SagException extends Exception

--- a/src/SagFileCache.php
+++ b/src/SagFileCache.php
@@ -29,7 +29,7 @@ require_once('SagException.php');
  * I/O operations.
  *
  * @package Cache 
- * @version 0.4.0
+ * @version 0.5.0
  */
 class SagFileCache extends SagCache 
 {

--- a/src/SagMemoryCache.php
+++ b/src/SagMemoryCache.php
@@ -26,7 +26,7 @@ require_once('SagException.php');
  * memory.
  *
  * @package Cache 
- * @version 0.4.0
+ * @version 0.5.0
  */
 class SagMemoryCache extends SagCache 
 {


### PR DESCRIPTION
Hey Sam,

I needed the ability to add information to a CouchDB database's security object (via PUT _security), and figured I'd put the code in Sag vs. just in the app. :)

So here 'tis. No test cases sadly, but it should be simple to write. The functions look like this:
    $sag->setAdmin('admin');
    $sag->setAdminRole('_admin');
    $sag->setReader('admin');
    $sag->setReaderRole('_admin');

Later,
Benjamin
