### PR TITLE
Added getSession() function to grab _session information.

### DIFF
--- a/src/Sag.php
+++ b/src/Sag.php
@@ -130,6 +130,15 @@ class Sag {
   }
 
   /**
+   * Get current session information on the server with /_session.
+   *
+   * @return stdClass
+   */
+  public function getSession() {
+    return $this->procPacket('GET', '/_session');
+  }
+
+  /**
    * Sets whether Sag will decode CouchDB's JSON responses with json_decode()
    * or to simply return the JSON as a string. Defaults to true.
    *


### PR DESCRIPTION
Added getSession method, needed to grab the _session for finding current user when authenticating with cookie authentication.

After using:

``` php
$sag->login("username", "password", Sag::$AUTH_COOKIE);
```

I found myself needing to access the session information (_session) to grab the current user's username. I would use public function get($url), but it requires a database prefix.

With the new getSession() function in the pull request, something like this is possible:

``` php
$username = $sag->getSession()->body->userCtx->name;
```

Still not the most elegant, but makes it accessible. It might also be worthwhile to have an option to pass the getSession() body back on $sag->login instead of just the autoSession, might be too much happening in that function, but it's a suggestion.
