### PR TITLE
Edited examples/phpSessions/CouchSessionStore.php via GitHub

### DIFF
--- a/examples/phpSessions/CouchSessionStore.php
+++ b/examples/phpSessions/CouchSessionStore.php
@@ -211,7 +211,7 @@ class CouchSessionStore
 
       foreach($rows as $row)
       {
-        if($row->doc->createdOn + $maxLife < $now)
+        if($row->doc->createdAt + $maxLife < $now)
         {
           $row->doc->_deleted = true;
           $toDelete[] = $row->doc;


### PR DESCRIPTION
The view created in the open() function contains a column named createdAt. The gc() function checks a column named createdOn. The results in a empty session table when gc() is called. This should fixed that.
