### PR TITLE
Check if a variable is set with the php function isset($var).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,24 @@
 Sag Changes
 ===========
 
+Version 0.6.1
+-------------
+
+Fixed Bugs
+
+  * Fixed a typo bug where I was trying to throw the concept of an Exception
+    instead of an instantiation. Luckily it is rare for this corner case in the
+    code to run. Thanks to Oliver Kurowski (github/a4mc) for reporting.
+    (closes #26)
+
+  * Fixed a problem with the HTTP/1.1 decoding of chunked message bodies that
+    was causing continuous change feed requests (/db/_changes?continuous=true)
+    to fail. (closes #27)
+
+  * Fixed a typo bug in examples/phpSessions, changed createdOn to createdAt.
+    Thanks to Yo-Han (github/yo-han) for finding the bug and submitting the
+    patch as a pull request. (closes #28)
+
 Version 0.6.0
 -------------
 

--- a/src/Sag.php
+++ b/src/Sag.php
@@ -1001,7 +1001,7 @@ class Sag {
 
           //some PHP configurations don't throw when fsockopen() fails
           if(!$sock) {
-            throw Exception($sockErrStr, $sockErrNo);
+            throw new Exception($sockErrStr, $sockErrNo);
           }
         }
         catch(Exception $e) {
@@ -1119,15 +1119,23 @@ class Sag {
          */
         if($chunkSize === null) {
           //Look for a chunk size
-          $chunkSize = hexdec(rtrim($line));
+          $line = rtrim($line);
 
-          if(!is_int($chunkSize)) {
-            throw new SagException('Invalid chunk size: '.$line);
+          if(!empty($line) || $line == "0") {
+            $chunkSize = hexdec($line);
+
+            if(!is_int($chunkSize)) {
+              throw new SagException('Invalid chunk size: '.$line);
+            }
           }
+        }
+        else if($chunkSize === 0) {
+          // We are done processing all the chunks.
+          $chunkParsingDone = true;
         }
         else if($chunkSize) {
           //We have a chunk size, so look for data
-          if(strlen($line) > $chunkSize) {
+          if(strlen($line) > $chunkSize && strlen($line) - 2 > $chunkSize) {
             throw new SagException('Unexpectedly large chunk on this line.');
           }
           else {
@@ -1142,11 +1150,7 @@ class Sag {
              */
             $chunkSize -= strlen($line);
 
-            if($chunkSize > 0) {
-              //Do not count the CRLF if not the end of the chunk.
-              $chunkSize += ($numCRLFs * 2);
-            }
-            else {
+            if($chunkSize <= 0) {
               /*
                * Nothing left to this chunk, so the next link is going to be
                * another chunk size. Or so we hope.
@@ -1154,10 +1158,6 @@ class Sag {
               $chunkSize = null;
             }
           }
-        }
-        else if($chunkSize === 0) {
-          // We are done processing all the chunks.
-          $chunkParsingDone = true;
         }
         else {
           throw new SagException('Unexpected empty line.');


### PR DESCRIPTION
Because the stdClass is dynamic, a variable can be avialbe, but must not be. Insteand of just checking if aviable (by accessing it) it's much more better to aks if the variable is realy set. Why? In development mode on php, you will get thousends of warnings (ok, there are 4) that a var is not set in this content.
So the parser can easier check itself (bool-check) than type-check to null.
