### PR TITLE
New "descending" paramater for getAllDOcs

### DIFF
--- a/src/Sag.php
+++ b/src/Sag.php
@@ -495,7 +495,7 @@ class Sag {
    *
    * @return mixed
    */
-  public function getAllDocs($incDocs = false, $limit = null, $startKey = null, $endKey = null, $keys = null) {
+  public function getAllDocs($incDocs = false, $limit = null, $startKey = null, $endKey = null, $keys = null, $descending = false) {
     if(!$this->db) {
       throw new SagException('No database specified.');
     }
@@ -532,6 +532,14 @@ class Sag {
       }
 
       $qry[] = 'limit='.urlencode($limit);
+    }
+
+    if($descending !== false) {
+      if(!is_bool($descending)) {
+        throw new SagException('getAllDocs() expected a boolean for descending.');
+      }
+
+      $qry[] = "descending=true";
     }
 
     $qry = '?'.implode('&', $qry);

--- a/tests/SagTest.php
+++ b/tests/SagTest.php
@@ -197,6 +197,9 @@ class SagTest extends PHPUnit_Framework_TestCase
     $this->assertTrue(isset($resDefaults->body->rows[0]->value));
     $this->assertFalse(isset($resDefaults->body->rows[0]->doc));
 
+    $resDescending = $this->couch->getAllDocs(true, null, '[]', '""', null, true);
+    $this->assertEquals('1', end($resDescending->body->rows)->id);
+
     $resAllWithDocs = $this->couch->getAllDocs(true, null, '""', '[]');
     $this->assertTrue(is_array($resAllWithDocs->body->rows));
     $this->assertTrue(isset($resAllWithDocs->body->rows[0]->value));


### PR DESCRIPTION
This is a simple modification (and the associated test) which adds a new "descending" parameter to getAllDocs.

I'm a bit worried that the test only passes if it's after the first of the getAllDocs tests. If I put the test at the end of test_getAllDocs, it fails (also note that all tests don't pass on my machine).
