### PR TITLE
PHP 5.2 compatible ternary operator

### DIFF
--- a/src/Sag.php
+++ b/src/Sag.php
@@ -950,7 +950,7 @@ class Sag {
    * @see setCookie()
    */
   public function getCookie($key) {
-    return ($this->globalCookies[$key]) ?: null;
+    return ($this->globalCookies[$key]) ? $this->globalCookies[$key] : null;
   }
 
   /**


### PR DESCRIPTION
PHP 5.3 added ex1 ?: ex2 as shorthand for ex1 ? ex1 : ex2.  Use the long form for backwards compatibility.
