### PR TITLE
Automatically use curl adapter when installed

### DIFF
--- a/src/Sag.php
+++ b/src/Sag.php
@@ -98,7 +98,7 @@ class Sag {
    */
   public function setHTTPAdapter($type = null) {
     if(!$type) {
-      $type = self::$HTTP_NATIVE_SOCKETS;
+      $type = extension_loaded("curl") ? self::$HTTP_CURL : self::$HTTP_NATIVE_SOCKETS;
     }
 
     // nothing to be done


### PR DESCRIPTION
Curl adapter is, according to yourself on some issues, faster and more reliable and should be used if possible. This patch allows to automatically detect the presence of curl module and use the curl adapter if the curl module is present.
