### PR TITLE
Expose $assoc param of json_decode with optional decode() param

### DIFF
--- a/src/httpAdapters/SagHTTPAdapter.php
+++ b/src/httpAdapters/SagHTTPAdapter.php
@@ -9,7 +9,8 @@
  */
 abstract class SagHTTPAdapter {
   public $decodeResp = true;
-
+  public $decodeRespAssoc = false;
+  
   protected $host;
   protected $port;
 
@@ -67,7 +68,7 @@ abstract class SagHTTPAdapter {
        * attachment as text/plain and then expecting it to be parsed by
        * json_decode().
        */
-      $json = json_decode($response->body);
+      $json = json_decode($response->body, $this->decodeRespAssoc);
 
       if(isset($json)) {
         /*


### PR DESCRIPTION
An extra optional boolean parameter is added to the decode() function to
allow specifying whether the returned decoded objects should be
converted into associative arrays. Using json_decode for this is the
most efficient way of doing the conversion.
