### PR TITLE
Fix offset notices and fatal error

### DIFF
--- a/src/httpAdapters/SagCURLHTTPAdapter.php
+++ b/src/httpAdapters/SagCURLHTTPAdapter.php
@@ -93,7 +93,7 @@ class SagCURLHTTPAdapter extends SagHTTPAdapter {
       $response->body = '';
 
       // split headers and body
-      list($headers, $response->body) = explode("\r\n\r\n", $chResponse, 1);
+      list($headers, $response->body) = explode("\r\n\r\n", $chResponse, 2);
 
       // split up the headers
       $headers = explode("\r\n", $headers);


### PR DESCRIPTION
The `$limit` should be set to 2. As this solution results in errors:
- Notice: Undefined offset: 1 in src/httpAdapters/SagCURLHTTPAdapter.php on line 96
- Fatal error: Cannot access empty property in src/httpAdapters/SagCURLHTTPAdapter.php on line 115

The docs for limit param say: If limit is set and positive, the returned array will contain a maximum of limit elements with the last element containing the rest of string.
