### PR TITLE
Use correct vendor name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sag/sag",
+  "name": "sbisbee/sag",
   "type": "library",
   "description": "A simple but powerful PHP library for talking to CouchDB.",
   "homepage": "http://www.saggingcouch.com/",


### PR DESCRIPTION
When composer tries to install the package it fails:

```
  Problem 1
    - The requested package sbisbee/sag could not be found in any version, there may be a typo in the package name.
```

The github username is sbisbee and not sag.
