### PR TITLE
Update SagCURLHTTPAdapter.php

### DIFF
--- a/src/httpAdapters/SagCURLHTTPAdapter.php
+++ b/src/httpAdapters/SagCURLHTTPAdapter.php
@@ -85,7 +85,7 @@ class SagCURLHTTPAdapter extends SagHTTPAdapter {
       }
       else {
         $opts[CURLOPT_SSL_VERIFYPEER] = true;
-        $opts[CURLOPT_SSL_VERIFYHOST] = true;
+        $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         $opts[CURLOPT_CAINFO] = $this->sslCertPath;
       }
     }


### PR DESCRIPTION
CURLOPT_SSL_VERIFYHOST: Support for value 1 removed in cURL 7.28.1 (http://php.net/manual/en/function.curl-setopt.php)
