### PR TITLE
reset stale curl options before setting new ones

### DIFF
--- a/src/httpAdapters/SagCURLHTTPAdapter.php
+++ b/src/httpAdapters/SagCURLHTTPAdapter.php
@@ -90,6 +90,7 @@ class SagCURLHTTPAdapter extends SagHTTPAdapter {
       }
     }
 
+    curl_reset($this->ch);
     curl_setopt_array($this->ch, $opts);
 
     $chResponse = curl_exec($this->ch);


### PR DESCRIPTION
Fixes strange behaviors when reusing the curl handle for multiple requests.

For example, the first request might set data (e.g., CURLOPT_POSTFIELDS).  When the second request is made, if it does not also set data - e.g., a GET request - the stale data will be sent to the server, resulting in various problems.