### PR TITLE
Fixes for issue #88

### DIFF
--- a/src/SagUserUtils.php
+++ b/src/SagUserUtils.php
@@ -135,7 +135,7 @@ class SagUserUtils {
    * the updated document to the server as well.
    *
    * @param object $doc The user document. Expected to look like what
-   * SagUserUtils->getUser() returns.
+   * SagUserUtils->getUser()->body returns.
    *
    * @param string $newPassword The new password for the user.
    *
@@ -159,7 +159,10 @@ class SagUserUtils {
       throw new SagException('Empty password are not allowed.');
     }
 
-    $doc->password_sha = sha1($newPassword + self::makeSalt());
+    $salt = self::makeSalt();
+
+    $doc->password_sha = sha1($newPassword . $salt);
+    $doc->salt = $salt;
 
     return ($upload) ? $this->sag->put($doc->_id, $doc) : $doc;
   }

--- a/src/SagUserUtils.php
+++ b/src/SagUserUtils.php
@@ -151,18 +151,24 @@ class SagUserUtils {
       throw new SagException('This does not look like a document: there is no _id.');
     }
 
-    if(empty($doc->salt) || empty($doc->password_sha)) {
-      throw new SagException('This does not look like a user or it is an admin. Change admin passwords via the server config.');
-    }
-
     if(empty($newPassword)) {
       throw new SagException('Empty password are not allowed.');
     }
 
-    $salt = self::makeSalt();
+    if(empty($doc->salt) || empty($doc->password_sha)) {
+      if( empty($doc->iterations) ) {
+        throw new SagException('This does not look like a user or it is an admin. Change admin passwords via the server config.');
+      } else {
+        /* This is CouchDB 1.3.0+; it automatically takes a plaintext password and converts it to PBKDF2 */
+        $doc->password = $newPassword;
+      }
+    } else {
 
-    $doc->password_sha = sha1($newPassword . $salt);
-    $doc->salt = $salt;
+      $salt = self::makeSalt();
+
+      $doc->password_sha = sha1($newPassword . $salt);
+      $doc->salt = $salt;
+    }
 
     return ($upload) ? $this->sag->put($doc->_id, $doc) : $doc;
   }


### PR DESCRIPTION
This commit fixes a couple issues.

1) SagUserUtils->changePassword() was not working. It was recording a
new SHA1 without also updating the salt used for the new password. It
would then update the password but the user could never log in again as
the salt didn’t match the new SHA1 hash. Additionally, in CouchDB 1.3.0+, 
PBKDF2 hashing is the new standard, I've added code to support changing
the passwords of users using this hash method.

2) The documentation stated that SagUserUtils->getUser() is what $doc
was expected to be like. If $doc was passed in from that method
however, it did not work. It needs the ->body property from the
returned object.