### PR TITLE
Fixes undefined index 'feof' in Native Adapter

### DIFF
--- a/src/httpAdapters/SagNativeHTTPAdapter.php
+++ b/src/httpAdapters/SagNativeHTTPAdapter.php
@@ -128,7 +128,7 @@ class SagNativeHTTPAdapter extends SagHTTPAdapter {
     // Read in the response.
     while(
       !$chunkParsingDone &&
-      !feof($sock) && 
+      !feof($sock) &&
       (
         $isHeader ||
         (
@@ -169,7 +169,7 @@ class SagNativeHTTPAdapter extends SagHTTPAdapter {
         $line = fgets($sock);
       }
 
-      if(!$line && !$sockInfo['feof'] && !$sockInfo['timed_out']) {
+      if(!$line && !$sockInfo['eof'] && !$sockInfo['timed_out']) {
         throw new SagException('Unexpectedly failed to retrieve a line from the socket before the end of the file.');
       }
 


### PR DESCRIPTION
$sockInfo is a result of stream_get_meta_data() and therefore the index 'feof' does not exist. The test should be against the 'eof' index.

This fixes the following error:
exception 'ErrorException' with message 'Undefined index: feof' in
src/httpAdapters/SagNativeHTTPAdapter.php:172
