### PR TITLE
Add the JSON_BIGINT_AS_STRING option to the json_decode call.

### DIFF
--- a/src/httpAdapters/SagHTTPAdapter.php
+++ b/src/httpAdapters/SagHTTPAdapter.php
@@ -65,7 +65,12 @@ abstract class SagHTTPAdapter {
       !empty($response->headers->{'content-type'}) &&
       $response->headers->{'content-type'} == 'application/json'
     ) {
-      $json = json_decode($response->body);
+      if(defined(JSON_BIGINT_AS_STRING)) {
+        $json = json_decode($response->body, false, 512, JSON_BIGINT_AS_STRING);
+      }
+      else {
+        $json = json_decode($response->body);
+      }
 
       if(isset($json)) {
         if(!empty($json->error)) {


### PR DESCRIPTION
When decoding large numbers, `json_decode` creates a notice.

This change uses the JSON_BIGINT_AS_STRING option, if it exists (PHP 5.4.0+).

See [Example #5](http://php.net/manual/en/function.json-decode.php) here.
